### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/philipphermes/planning-poker/security/code-scanning/3](https://github.com/philipphermes/planning-poker/security/code-scanning/3)

To fix the problem, explicitly add a `permissions:` block at the workflow level, setting the permission to the least privilege required for the workflow to function correctly. All jobs only require read access to the repository contents (for checking out code), as there are no actions that write or modify repository state. The Codecov upload step only needs access to coverage reports and does not require repository write permissions; the authentication is done via the Codecov token.

**Best solution:**  
Add the following block after the `name: CI` line (typically right before or after the `on:` block is also valid) in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

**Implementation steps:**  
- In `.github/workflows/ci.yml`, after `name: CI`, insert the above lines at line 2 (moving the existing content down).
- No additional imports, methods, or variable definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
